### PR TITLE
Import Instagram archive to generate a "photoblog"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ phf = { version = "0.11", features = ["macros"] }
 pulldown-cmark = "0.12"
 regex = "1"
 reqwest = { version= "0.12.12", default-features = false, features = ["blocking", "rustls-tls"] }
+scraper = "0.23.1"
 secp256k1 = { version = "0.27", features = ["global-context", "serde", "bitcoin_hashes", "rand-std"] }
 serde = "1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ globset = "0.4"
 grass = { version = "0.13", default-features = false, features = ["random"] }
 hex = "0.4.3"
 http-types = "2"
+image = "0.25.8"
 lazy_static = "1.4"
 mime_guess = "2.0"
 phf = { version = "0.11", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tide-websockets = "0"
 time = "=0.3.39"
 tl = "0"
 toml = "0"
+url = "2.5.7"
 walkdir = "2"
 zip = { version = "3", default-features = false, features = ["deflate"] }
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ NB: in order to obtain Let's Encrypt certificates you must be running Servus on 
 
 PS: You can try running the SSL version locally using a custom certificate by passing `--ssl-cert` and `--ssl-key` if you map `127.0.0.1` to your domain name from `/etc/hosts` and get a realistic simulation of the live environment on your local machine!
 
+## Importing your content
+
+When creating a new site you are asked whether you want to import your Instagram content. You can get a dump of all your Instagram data from the app and Servus will happily import all your pictures. Great way to get started with an old school photoblog that you can self-host (and is Nostr ready)!
+
 ## Managing your content
 
 **Post using any Nostr client** such as [YakiHonne](https://yakihonne.com/) (they have good mobile apps!).

--- a/src/ig.rs
+++ b/src/ig.rs
@@ -1,0 +1,65 @@
+use anyhow::{Context, Result};
+use chrono::NaiveDateTime;
+use scraper::{Html, Selector};
+use std::{fs::File, io::Read};
+use zip::read::ZipArchive;
+
+pub struct Post {
+    pub date: NaiveDateTime,
+    pub image_data: Vec<u8>,
+}
+
+pub fn import_ig<'a>(zip_path: &str) -> Result<impl Iterator<Item = Result<Post>> + 'a> {
+    let file = File::open(zip_path).context("Failed to open file.")?;
+    let mut archive = ZipArchive::new(file).context("Failed to read zip archive")?;
+
+    let mut html_data = String::new();
+    for i in 0..archive.len() {
+        let mut f = archive.by_index(i)?;
+        if f.name().contains("posts_1.html") {
+            f.read_to_string(&mut html_data)?;
+            break;
+        }
+    }
+
+    let posts: Vec<Result<Post>> = Html::parse_document(&html_data)
+        .select(&Selector::parse("div.pam").unwrap())
+        .filter_map(|post| {
+            let date = post
+                .select(&Selector::parse("._3-94").unwrap())
+                .next()
+                .map(|t| t.text().collect::<String>())
+                .unwrap_or("".into());
+
+            let Ok(date) = NaiveDateTime::parse_from_str(&date, "%B %d, %Y %I:%M %p") else {
+                println!("Unknown date");
+                return None;
+            };
+
+            let img_src = post
+                .select(&Selector::parse("img").unwrap())
+                .next()
+                .and_then(|img| img.value().attr("src"))
+                .unwrap_or("".into());
+
+            if img_src.is_empty() {
+                println!("Image link not found");
+                return None;
+            }
+
+            // For eager reading, reopen the zip
+            let file = File::open(zip_path).ok()?;
+            let mut archive = ZipArchive::new(file).ok()?;
+            let mut image_data = Vec::new();
+            archive
+                .by_name(&img_src)
+                .ok()?
+                .read_to_end(&mut image_data)
+                .ok()?;
+
+            Some(Ok(Post { date, image_data }))
+        })
+        .collect();
+
+    Ok(posts.into_iter())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,19 @@ fn get_site(request: &Request<State>) -> Option<Site> {
                         .unwrap()
                         .register_function(
                             "get_url",
-                            template::GetUrl::new(site.domain.clone(), site.config.clone()),
+                            template::GetUrl::new(request.state().root_path.clone(), site.clone()),
+                        );
+                    site.tera
+                        .write()
+                        .unwrap()
+                        .as_mut()
+                        .unwrap()
+                        .register_function(
+                            "resize_image",
+                            template::ResizeImage::new(
+                                request.state().root_path.clone(),
+                                site.clone(),
+                            ),
                         );
                     return Some(site);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,6 +391,11 @@ async fn handle_request(request: Request<State>) -> tide::Result<Response> {
 
     let mut part: Option<String> = None;
     if path.contains(".") {
+        let path = if path.contains("/") {
+            path.split("/").collect::<Vec<_>>().last().unwrap()
+        } else {
+            path
+        };
         let parts = path.split(".").collect::<Vec<_>>();
         if parts.len() == 2 {
             part = Some(parts[0].to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -818,7 +818,6 @@ async fn handle_blossom_list_request(request: Request<State>) -> tide::Result<Re
     };
 
     let mut list = vec![];
-
     for path in &paths {
         if path.path().extension().is_none() {
             let metadata = FileMetadata::read(
@@ -1216,12 +1215,7 @@ fn validate_themes(
                 continue;
             }
         }
-        match site::load_templates(
-            root_path,
-            &empty_site,
-            &empty_site.domain,
-            &empty_site.config,
-        ) {
+        match site::load_templates(root_path, &empty_site, &empty_site.config) {
             Ok(tera) => {
                 empty_site.tera = Arc::new(RwLock::new(Some(tera)));
             }
@@ -1497,12 +1491,7 @@ mod tests {
 
         let empty_site = Site::empty(&"hyde");
 
-        site::load_templates(
-            root_path,
-            &empty_site,
-            &empty_site.domain,
-            &empty_site.config,
-        )?;
+        site::load_templates(root_path, &empty_site, &empty_site.config)?;
 
         Ok(())
     }

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -179,6 +179,24 @@ impl Event {
         return None;
     }
 
+    pub fn get_picture_hash(&self) -> Option<String> {
+        if self.kind != EVENT_KIND_PICTURE {
+            return None;
+        }
+
+        for t in &self.tags[..] {
+            if t[0] == "imeta" {
+                for imeta_tag in &t[1..] {
+                    if imeta_tag.starts_with("x ") {
+                        return Some(imeta_tag[2..].to_string());
+                    }
+                }
+            }
+        }
+
+        return None;
+    }
+
     fn get_long_form_published_at(&self) -> Option<NaiveDateTime> {
         if self.kind != EVENT_KIND_LONG_FORM && self.kind != EVENT_KIND_LONG_FORM_DRAFT {
             return None;

--- a/src/site.rs
+++ b/src/site.rs
@@ -52,6 +52,10 @@ fn default_feed_filename() -> String {
     return "atom.xml".to_string();
 }
 
+fn default_feed_filenames() -> Vec<String> {
+    return vec!["atom.xml".to_string()];
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SiteConfig {
     pub base_url: String,
@@ -63,8 +67,11 @@ pub struct SiteConfig {
     pub description: Option<String>,
 
     // required by some themes
+    pub author: Option<String>,
     #[serde(default = "default_feed_filename")]
     pub feed_filename: String,
+    #[serde(default = "default_feed_filenames")]
+    pub feed_filenames: Vec<String>,
     #[serde(default)]
     pub build_search_index: bool,
 
@@ -80,7 +87,9 @@ impl SiteConfig {
             theme: theme.to_string(),
             title: None,
             description: None,
+            author: None,
             feed_filename: default_feed_filename(),
+            feed_filenames: default_feed_filenames(),
             build_search_index: false,
             extra: HashMap::new(),
         }

--- a/src/site.rs
+++ b/src/site.rs
@@ -106,6 +106,10 @@ impl SiteConfig {
         self
     }
 
+    pub fn is_local_server(&self) -> bool {
+        self.base_url.starts_with("http://localhost:") || self.base_url.starts_with("http://127.0.0.1:")
+    }
+
     // https://github.com/getzola/zola/blob/master/components/config/src/config/mod.rs
 
     /// Makes a url, taking into account that the base url might have a trailing slash
@@ -134,9 +138,7 @@ impl SiteConfig {
             format!("{}/{}{}", self.base_url, path, trailing_bit)
         };
 
-        if self.base_url.starts_with("http://localhost:")
-            || self.base_url.starts_with("http://127.0.0.1:")
-        {
+        if self.is_local_server() {
             // rewrite links when running locally
             // to allow the server know what site they are referring to
             format!("{}?{}", permalink, site_domain)
@@ -158,11 +160,9 @@ pub fn load_templates(
 
     let mut tera = tera::Tera::new(&format!("{}/templates/**/*", theme_path))?;
     tera.autoescape_on(vec![]);
-    tera.register_function(
-        "get_url",
-        template::GetUrl::new(site_domain.to_string(), site_config.clone()),
-    );
+    tera.register_function("get_url", template::GetUrl::new(root_path.to_string(), site.clone()));
     tera.register_function("load_data", template::LoadData::new(site.clone()));
+    tera.register_function("resize_image", template::ResizeImage::new(root_path.to_string(), site.clone()));
 
     log::info!(
         "Loaded {} templates for {}",

--- a/src/site.rs
+++ b/src/site.rs
@@ -160,7 +160,6 @@ impl SiteConfig {
 pub fn load_templates(
     root_path: &str,
     site: &Site,
-    site_domain: &str,
     site_config: &SiteConfig,
 ) -> Result<tera::Tera> {
     log::debug!("Loading templates...");
@@ -566,7 +565,7 @@ pub fn load_site(
         tera: Arc::new(RwLock::new(None)),
     };
 
-    match load_templates(root_path, &site, domain, &config) {
+    match load_templates(root_path, &site, &config) {
         Ok(tera) => {
             site.tera = Arc::new(RwLock::new(Some(tera)));
             site.load_resources(root_path, secret_key)?;


### PR DESCRIPTION
* you can ask Instagram to provide a dump of all your data as a .zip file
* when creating a new site Servus now asks whether you want to import your Instagram archive
* importing your archive results in your pictures being imported into your local Blossom server and relevant Nostr events of kind 20 (NIP-68) are added to your local Nostr relay
* some more tweaks are done to support the [zallery](https://github.com/gamingrobot/zallery) theme, which looks good for an IG-like feed

Note: there is no pagination support yet, so a feed with a lot of images will take a long time to load...